### PR TITLE
Add a return to avoid multiple callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function folders(dir, tasks){
 			streams = folders.map(tasks);
 
 		if (streams.length === 0) {
-			done();
+			return done();
 		}
 
 		return es.merge.apply(null, streams);


### PR DESCRIPTION
when listing folders of an empty folder